### PR TITLE
chore: setup husky pre-commit hooks with lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "cypress run",
     "lint": "eslint .",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "prepare": "husky"
   },
   "engines": {
     "node": ">=18"
@@ -35,5 +36,14 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1"
+  },
+  "lint-staged": {
+    "**/*.{js,cjs,mjs}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "**/*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
This PR sets up Husky and lint-staged to enforce automated code quality checks before each commit.

The configuration ensures that linting and formatting are executed only on staged files, preventing inconsistent code from being committed to the repository.

- Initialized Husky Git hooks
- Added prepare script to enable Husky installation
- Configured pre-commit hook
- Integrated lint-staged
- Configured staged file validation:
   - eslint --fix for JavaScript files
   - prettier --write for JS, JSON, Markdown, and YAML files

How to Validate
Modify any JavaScript file with formatting or lint issues.
Stage the file:

> git add .

Attempt to commit:

> git commit -m "test: verify pre-commit hook"

Expected result:

- ESLint and Prettier run automatically.
- Fixable issues are corrected.
- The commit is blocked if critical lint errors are detected.

The repository now enforces consistent code standards at commit time, reducing technical debt, preventing style inconsistencies, and improving overall maintainability.