### PR TITLE
feat: add centralized test data management with fixtures and data utils

### DIFF
--- a/cypress/e2e/ui/books-search.cy.js
+++ b/cypress/e2e/ui/books-search.cy.js
@@ -1,4 +1,16 @@
 const booksPage = require('../../pages/books.page');
+const { loadFixture } = require('../../utils/data.utils');
+
+describe('Books - Search', () => {
+  it('filters results using centralized test data', () => {
+    booksPage.visit();
+
+    loadFixture('books/search.json').then((data) => {
+      booksPage.search(data.validSearchTerm);
+      booksPage.expectAllTitlesContain(data.validSearchTerm);
+    });
+  });
+});
 
 describe('Books - Search functionality', () => {
   beforeEach(() => {

--- a/cypress/e2e/ui/smoke.cy.js
+++ b/cypress/e2e/ui/smoke.cy.js
@@ -1,27 +1,11 @@
-// const loginPage = require('../../pages/login.page');
-// const profilePage = require('../../pages/profile.page');
-
-// describe('Smoke - Core Application Flow', () => {
-//   it('should login successfully and display user profile', () => {
-//     // 1️⃣ Visit login page
-//     loginPage.visit();
-
-//     // 2️⃣ Login using environment credentials
-//     loginPage.loginWithEnv();
-
-//     // 3️⃣ Validate redirect to profile
-//     cy.url().should('include', '/profile');
-
-//     // 4️⃣ Validate username is displayed correctly
-//     profilePage.expectUsernameFromEnv();
-//   });
-// });
-
 const profilePage = require('../../pages/profile.page');
+const { getCredentialsFromEnv } = require('../../utils/data.utils');
 
 describe('Smoke', () => {
-  it('login and validates profile', () => {
-    cy.loginWithSession();
-    profilePage.expectUsernameFromEnv();
+  it('logs in and validates profile', () => {
+    getCredentialsFromEnv().then(({ username, password }) => {
+      cy.login(username, password);
+      profilePage.expectUsername(username);
+    });
   });
 });

--- a/cypress/fixtures/books/expectations.json
+++ b/cypress/fixtures/books/expectations.json
@@ -1,0 +1,3 @@
+{
+  "expectedBooksCount": 8
+}

--- a/cypress/fixtures/books/search.json
+++ b/cypress/fixtures/books/search.json
@@ -1,0 +1,5 @@
+{
+  "validSearchTerm": "Git",
+  "noResultsSearchTerm": "___no_results___",
+  "caseInsensitiveTerm": "gIt"
+}

--- a/cypress/fixtures/users/user.json
+++ b/cypress/fixtures/users/user.json
@@ -1,0 +1,4 @@
+{
+  "usernameKey": "username",
+  "passwordKey": "password"
+}

--- a/cypress/utils/data.utils.js
+++ b/cypress/utils/data.utils.js
@@ -1,0 +1,25 @@
+/**
+ * Centralized test data access.
+ * - Non-sensitive data comes from fixtures
+ * - Sensitive data comes from env via cy.env(...)
+ */
+
+function loadFixture(path) {
+  return cy.fixture(path);
+}
+
+function getCredentialsFromEnv() {
+  return cy.env(['username', 'password', 'userId']).then(({ username, password, userId }) => {
+    if (!username || !password) {
+      throw new Error(
+        'Missing env vars: username/password. Check .env or CI secrets (CYPRESS_USERNAME / CYPRESS_PASSWORD).',
+      );
+    }
+    return { username, password, userId };
+  });
+}
+
+module.exports = {
+  loadFixture,
+  getCredentialsFromEnv,
+};


### PR DESCRIPTION
This PR introduces a centralized test data management strategy for the automation framework.

Non-sensitive test data has been moved to structured fixtures, while sensitive information remains managed through environment variables. A shared data utility module was implemented to standardize how tests access both fixture-based and environment-based data.

Changes
- Added structured fixtures under cypress/fixtures/ (e.g., books, users)
- Implemented a centralized data utility module
- Refactored existing tests to remove hardcoded values
- Ensured credentials remain managed exclusively through environment variables
- Improved separation between test logic and test data

How to Validate
Run:

> npm run lint

npm 

> run cy:run

Expected result:
- Tests execute successfully
- No hardcoded test data remains in specs
- Fixtures load correctly
- Environment variables continue to work as expected

The framework now follows a cleaner and more scalable test data strategy, improving maintainability and reducing duplication across the test suite.