### PR TITLE
test: add API validation for GET /BookStore/v1/Books

### DIFF
--- a/cypress/e2e/api/books.get.cy.js
+++ b/cypress/e2e/api/books.get.cy.js
@@ -1,0 +1,33 @@
+describe('API - GET /BookStore/v1/Books', () => {
+  it('TC-API-01 Get all books returns 200 and a valid books payload', () => {
+    cy.getBooks().then((res) => {
+      // Status
+      expect(res.status).to.eq(200);
+
+      // Basic shape
+      expect(res.body).to.have.property('books');
+      expect(res.body.books).to.be.an('array');
+
+      // Minimum integrity: not empty
+      expect(res.body.books.length).to.be.greaterThan(0);
+
+      // Required fields contract for each book
+      res.body.books.forEach((book) => {
+        expect(book).to.have.property('title');
+        expect(book.title).to.be.a('string').and.not.be.empty;
+
+        expect(book).to.have.property('author');
+        expect(book.author).to.be.a('string').and.not.be.empty;
+      });
+    });
+  });
+
+  it('TC-API-02 Response contains expected number of books (8 books) from centralized test data', () => {
+    cy.fixture('books/expectations.json').then(({ expectedBooksCount }) => {
+      cy.getBooks().then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body.books).to.have.length(expectedBooksCount);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces automated validation for the GET /BookStore/v1/Books endpoint.

The implementation verifies response status, dataset integrity, and required contract fields for each book. Expected dataset size is sourced from centralized test data to avoid hardcoded values.

Changes

- Added API test under cypress/e2e/api/
- Validated:
  - HTTP status code (200)
  - Presence of books array
  - Dataset size using centralized fixture data
  - Required fields (title, author) for each book
  - Reused existing cy.getBooks() custom command
  - Ensured no hardcoded expectations in test logic

How to Validate

Run:

> npm run cy:run

The framework now includes foundational API validation coverage for the Books endpoint, ensuring response consistency and basic contract integrity.