### PR TITLE
style: apply prettier formatting to API tests

### DIFF
--- a/cypress/e2e/api/books.get.cy.js
+++ b/cypress/e2e/api/books.get.cy.js
@@ -1,17 +1,31 @@
 describe('API - GET /BookStore/v1/Books', () => {
-  it('TC-API-01 Get all books returns 200 and a valid books payload', () => {
+  // Issue: Validate response status and schema
+  it('TC-API-01 — Get all books returns 200', () => {
     cy.getBooks().then((res) => {
-      // Status
       expect(res.status).to.eq(200);
-
-      // Basic shape
       expect(res.body).to.have.property('books');
       expect(res.body.books).to.be.an('array');
-
-      // Minimum integrity: not empty
       expect(res.body.books.length).to.be.greaterThan(0);
+    });
+  });
 
-      // Required fields contract for each book
+  // Issue: Validate dataset integrity (8 books expected)
+  it('TC-API-02 — Response contains expected number of books (dataset integrity)', () => {
+    cy.fixture('books/expectations.json').then(({ expectedBooksCount }) => {
+      cy.getBooks().then((res) => {
+        expect(res.status).to.eq(200);
+        expect(res.body).to.have.property('books');
+        expect(res.body.books).to.have.length(expectedBooksCount);
+      });
+    });
+  });
+
+  // Issue: Validate required fields (title, author)
+  it('TC-API-03 — Contract validation: required fields exist', () => {
+    cy.getBooks().then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body.books).to.be.an('array').and.not.be.empty;
+
       res.body.books.forEach((book) => {
         expect(book).to.have.property('title');
         expect(book.title).to.be.a('string').and.not.be.empty;
@@ -22,11 +36,33 @@ describe('API - GET /BookStore/v1/Books', () => {
     });
   });
 
-  it('TC-API-02 Response contains expected number of books (8 books) from centralized test data', () => {
-    cy.fixture('books/expectations.json').then(({ expectedBooksCount }) => {
-      cy.getBooks().then((res) => {
-        expect(res.status).to.eq(200);
-        expect(res.body.books).to.have.length(expectedBooksCount);
+  // Issue: Validate response status and schema
+  it('TC-API-04 — Contract validation: key fields are valid types', () => {
+    cy.getBooks().then((res) => {
+      expect(res.status).to.eq(200);
+      expect(res.body.books).to.be.an('array').and.not.be.empty;
+
+      res.body.books.forEach((book) => {
+        // key fields
+        expect(book).to.have.property('isbn');
+        expect(book.isbn).to.be.a('string').and.not.be.empty;
+
+        expect(book).to.have.property('title');
+        expect(book.title).to.be.a('string').and.not.be.empty;
+
+        expect(book).to.have.property('author');
+        expect(book.author).to.be.a('string').and.not.be.empty;
+
+        // optional: publish_date parseable (if present)
+        if (book.publish_date != null) {
+          expect(book.publish_date).to.be.a('string').and.not.be.empty;
+          expect(Date.parse(book.publish_date), 'publish_date should be parseable').to.not.be.NaN;
+        }
+
+        // no unexpected nulls for required fields
+        expect(book.title).to.not.equal(null);
+        expect(book.author).to.not.equal(null);
+        expect(book.isbn).to.not.equal(null);
       });
     });
   });


### PR DESCRIPTION
This PR implements API validation for the GET /BookStore/v1/Books endpoint, focusing on response status and contract/schema verification.

The tests ensure the endpoint returns a successful response and that the key fields in the response payload meet the expected structure and type requirements.

Changes

- Implemented TC-API-01:
- Validates HTTP 200 OK
- Verifies the presence of the books array
- Implemented TC-API-04:
- Validates required key fields (isbn, title, author)
- Ensures fields are non-empty strings
- Validates publish_date is parseable when present
- Ensures no unexpected null values for required fields
- Applied Prettier formatting and ensured lint passes
- 

How to Validate

Run:

> npm run lint

npx 

> cypress run --spec "cypress/e2e/api/books.get.cy.js"