### PR TITLE
test: validate dataset integrity and idempotency for books endpoint

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,8 @@ function loadEnvironmentConfig(environment) {
 }
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
     setupNodeEvents(on, config) {
       const environment = config.env.environment || 'qa';

--- a/cypress/e2e/api/books.get.cy.js
+++ b/cypress/e2e/api/books.get.cy.js
@@ -66,4 +66,24 @@ describe('API - GET /BookStore/v1/Books', () => {
       });
     });
   });
+
+  it('TC-API-05 — Idempotency: repeated calls return consistent dataset', () => {
+    cy.fixture('books/expectations.json').then(({ expectedBooksCount }) => {
+      cy.getBooks().then((firstRes) => {
+        expect(firstRes.status).to.eq(200);
+        expect(firstRes.body.books).to.have.length(expectedBooksCount);
+
+        const firstIsbnSet = firstRes.body.books.map((b) => b.isbn).sort();
+
+        cy.getBooks().then((secondRes) => {
+          expect(secondRes.status).to.eq(200);
+          expect(secondRes.body.books).to.have.length(expectedBooksCount);
+
+          const secondIsbnSet = secondRes.body.books.map((b) => b.isbn).sort();
+
+          expect(secondIsbnSet).to.deep.equal(firstIsbnSet);
+        });
+      });
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -556,9 +556,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1106,13 +1106,16 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint": {
@@ -1230,19 +1233,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/espree": {
@@ -1443,6 +1433,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {


### PR DESCRIPTION
Adds API tests to validate dataset integrity for GET /BookStore/v1/Books.
The suite verifies the expected number of books and ensures the dataset remains consistent across repeated calls.

Changes

- TC-API-02: Validates the books array length matches the expected dataset size (read from centralized fixture data).
- TC-API-05: Validates idempotency by calling the endpoint twice and comparing the ISBN set (order-independent).
- 

Keeps expectations centralized (no hardcoded dataset count in test code).

How to Validate

> npm run lint

> npx cypress run --spec "cypress/e2e/api/books.get.cy.js"